### PR TITLE
Investigate deleting resources

### DIFF
--- a/ckanext/romania_theme/logic/auth/delete.py
+++ b/ckanext/romania_theme/logic/auth/delete.py
@@ -8,7 +8,8 @@ ERROR_STRING = """Nu este permisa stergerea datelor la mai mult de 5 zile dupa
 
 def romania_theme_package_delete(context, data_dict):
     model = context['model']
-    package = model.Session.query(model.Package).get(data_dict['id'])
+    package = model.Package.get(data_dict['id'])
+
     if datetime.now() - package.metadata_created > timedelta(days=5):
         return {'success': False, 'msg': ERROR_STRING}
     return package_delete(context, data_dict)
@@ -16,7 +17,8 @@ def romania_theme_package_delete(context, data_dict):
 
 def romania_theme_resource_delete(context, data_dict):
     model = context['model']
-    resource = model.Session.query(model.Resource).get(data_dict['id'])
+    resource = model.Resource.get(data_dict['id'])
+
     if datetime.now() - resource.created > timedelta(days=5):
         return {'success': False, 'msg': ERROR_STRING}
     return resource_delete(context, data_dict)


### PR DESCRIPTION
Somebody claims that deleting resources is not possible anymore after I tweaked in auth the possibility to delete only before a deadline of 5 days before creation.

Investigate that claim.

_PS: sorry for no logs._
